### PR TITLE
[BUGFIX] Make PauseSubState texts tween from zero transparency

### DIFF
--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -313,6 +313,7 @@ class PauseSubState extends MusicBeatSubState
     var delay:Float = 0.1;
     for (child in metadata.members)
     {
+      child.alpha = 0;
       FlxTween.tween(child, {alpha: 1, y: child.y + 5}, 1.8, {ease: FlxEase.quartOut, startDelay: delay});
       delay += 0.1;
     }


### PR DESCRIPTION
The name speaks for itself

Makes texts appear more beautiful (as in previous versions)